### PR TITLE
Fix Service Provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ $app = new \Slim\App();
 // Register middleware
 $app->add(new \Slim\HttpCache\Cache('public', 86400));
 
+// Fetch DI Container
+$container = $app->getContainer();
+
 // Register service provider
-$app->register(new \Slim\HttpCache\CacheProvider);
+$container->register(new \Slim\HttpCache\CacheProvider);
 
 // Example route with ETag header
 $app->get('/foo', function ($req, $res, $args) {


### PR DESCRIPTION
\Slim\App is no longer a instance of \Pimple\Container. This affects registration of Pimple Service Providers. See issue https://github.com/slimphp/Slim/issues/1250.