### PR TITLE
Separate cache relevant methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,11 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "slim/slim": "dev-develop"
+        "slim/slim": "^3.0@dev"
     },
     "autoload": {
         "psr-4": {
-            "Slim\\HttpCache\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Slim\\HttpCache\\Tests\\": "tests"
+            "Slim\\Middleware\\HttpCache\\": "src"
         }
     }
 }

--- a/src/CacheHelper.php
+++ b/src/CacheHelper.php
@@ -1,0 +1,153 @@
+<?php
+namespace Slim\Middleware\HttpCache;
+
+use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class CacheHelper
+{
+    /**
+     * Enable client-side HTTP caching
+     *
+     * @param  ResponseInterface $response PSR7 response object
+     * @param  string            $type     Cache-Control type: "private" or "public"
+     * @param  null|int|string   $maxAge   Maximum cache age (integer timestamp or datetime string)
+     *
+     * @return ResponseInterface           A new PSR7 response object with `Cache-Control` header
+     * @throws InvalidArgumentException if the cache-control type is invalid
+     */
+    public function allowCache(ResponseInterface $response, $type = 'private', $maxAge = null)
+    {
+        if (!in_array($type, ['private', 'public'])) {
+            throw new InvalidArgumentException('Invalid Cache-Control type. Must be "public" or "private".');
+        }
+        $headerValue = $type;
+        if ($maxAge) {
+            if (!is_integer($maxAge)) {
+                $maxAge = strtotime($maxAge);
+            }
+            $headerValue = $headerValue . ', max-age=' . $maxAge;
+        }
+
+        return $response->withHeader('Cache-Control', $headerValue);
+    }
+
+    /**
+     * Disable client-side HTTP caching
+     *
+     * @param  ResponseInterface $response PSR7 response object
+     *
+     * @return ResponseInterface           A new PSR7 response object with `Cache-Control` header
+     */
+    public function denyCache(ResponseInterface $response)
+    {
+        return $response->withHeader('Cache-Control', 'no-store,no-cache');
+    }
+
+    /**
+     * Add `Expires` header to PSR7 response object
+     *
+     * @param  ResponseInterface $response A PSR7 response object
+     * @param  int|string        $time     A UNIX timestamp or a valid `strtotime()` string
+     *
+     * @return ResponseInterface           A new PSR7 response object with `Expires` header
+     * @throws InvalidArgumentException if the expiration date cannot be parsed
+     */
+    public function withExpires(ResponseInterface $response, $time)
+    {
+        if (!is_integer($time)) {
+            $time = strtotime($time);
+            if ($time === false) {
+                throw new InvalidArgumentException('Expiration value could not be parsed with `strtotime()`.');
+            }
+        }
+
+        return $response->withHeader('Expires', gmdate('D, d M Y H:i:s T', $time));
+    }
+
+    /**
+     * Add `ETag` header to PSR7 response object
+     *
+     * @param  ResponseInterface $response A PSR7 response object
+     * @param  string            $value    The ETag value
+     * @param  string            $type     ETag type: "strong" or "weak"
+     *
+     * @return ResponseInterface           A new PSR7 response object with `ETag` header
+     * @throws InvalidArgumentException if the etag type is invalid
+     */
+    public function withEtag(ResponseInterface $response, $value, $type = 'strong')
+    {
+        if (!in_array($type, ['strong', 'weak'])) {
+            throw new InvalidArgumentException('Invalid etag type. Must be "strong" or "weak".');
+        }
+        $value = '"' . $value . '"';
+        if ($type === 'weak') {
+            $value = 'W/' . $value;
+        }
+
+        return $response->withHeader('ETag', $value);
+    }
+
+    /**
+     * Add `Last-Modified` header to PSR7 response object
+     *
+     * @param  ResponseInterface $response A PSR7 response object
+     * @param  int|string        $time     A UNIX timestamp or a valid `strtotime()` string
+     *
+     * @return ResponseInterface           A new PSR7 response object with `Last-Modified` header
+     * @throws InvalidArgumentException if the last modified date cannot be parsed
+     */
+    public function withLastModified(ResponseInterface $response, $time)
+    {
+        if (!is_integer($time)) {
+            $time = strtotime($time);
+            if ($time === false) {
+                throw new InvalidArgumentException('Last Modified value could not be parsed with `strtotime()`.');
+            }
+        }
+
+        return $response->withHeader('Last-Modified', gmdate('D, d M Y H:i:s T', $time));
+    }
+
+    /**
+     * Compares the request and the response to determine if the client still has a valid copy.
+     *
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     * @return bool
+     */
+    public function isStillValid(RequestInterface $request, ResponseInterface $response)
+    {
+        // Last-Modified header and conditional GET check
+        $lastModified = $response->getHeaderLine('Last-Modified');
+
+        if ($lastModified) {
+            if (!is_integer($lastModified)) {
+                $lastModified = strtotime($lastModified);
+            }
+
+            $ifModifiedSince = $request->getHeaderLine('If-Modified-Since');
+
+            if ($ifModifiedSince && $lastModified <= strtotime($ifModifiedSince)) {
+                return true;
+            }
+        }
+
+        // ETag header and conditional GET check
+        $etag = $response->getHeaderLine('ETag');
+
+        if ($etag) {
+            $ifNoneMatch = $request->getHeaderLine('If-None-Match');
+
+            if ($ifNoneMatch) {
+                $etagList = preg_split('@\s*,\s*@', $ifNoneMatch);
+                if (in_array(str_replace('"', '', $etag), $etagList) || in_array('*', $etagList)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/CacheProvider.php
+++ b/src/CacheProvider.php
@@ -1,10 +1,8 @@
 <?php
-namespace Slim\HttpCache;
+namespace Slim\Middleware\HttpCache;
 
-use InvalidArgumentException;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Psr\Http\Message\ResponseInterface;
 
 class CacheProvider implements ServiceProviderInterface
 {
@@ -15,109 +13,8 @@ class CacheProvider implements ServiceProviderInterface
      */
     public function register(Container $container)
     {
-        $container['cache'] = $this;
-    }
-
-    /**
-     * Enable client-side HTTP caching
-     *
-     * @param  ResponseInterface $response PSR7 response object
-     * @param  string            $type     Cache-Control type: "private" or "public"
-     * @param  null|int|string   $maxAge   Maximum cache age (integer timestamp or datetime string)
-     *
-     * @return ResponseInterface           A new PSR7 response object with `Cache-Control` header
-     * @throws InvalidArgumentException if the cache-control type is invalid
-     */
-    public function allowCache(ResponseInterface $response, $type = 'private', $maxAge = null)
-    {
-        if (!in_array($type, ['private', 'public'])) {
-            throw new InvalidArgumentException('Invalid Cache-Control type. Must be "public" or "private".');
-        }
-        $headerValue = $type;
-        if ($maxAge) {
-            if (!is_integer($maxAge)) {
-                $maxAge = strtotime($maxAge);
-            }
-            $headerValue = $headerValue . ', max-age=' . $maxAge;
-        }
-
-        return $response->withHeader('Cache-Control', $headerValue);
-    }
-
-    /**
-     * Disable client-side HTTP caching
-     *
-     * @param  ResponseInterface $response PSR7 response object
-     *
-     * @return ResponseInterface           A new PSR7 response object with `Cache-Control` header
-     */
-    public function denyCache(ResponseInterface $response)
-    {
-        return $response->withHeader('Cache-Control', 'no-store,no-cache');
-    }
-
-    /**
-     * Add `Expires` header to PSR7 response object
-     *
-     * @param  ResponseInterface $response A PSR7 response object
-     * @param  int|string        $time     A UNIX timestamp or a valid `strtotime()` string
-     *
-     * @return ResponseInterface           A new PSR7 response object with `Expires` header
-     * @throws InvalidArgumentException if the expiration date cannot be parsed
-     */
-    public function withExpires(ResponseInterface $response, $time)
-    {
-        if (!is_integer($time)) {
-            $time = strtotime($time);
-            if ($time === false) {
-                throw new InvalidArgumentException('Expiration value could not be parsed with `strtotime()`.');
-            }
-        }
-
-        return $response->withHeader('Expires', gmdate('D, d M Y H:i:s T', $time));
-    }
-
-    /**
-     * Add `ETag` header to PSR7 response object
-     *
-     * @param  ResponseInterface $response A PSR7 response object
-     * @param  string            $value    The ETag value
-     * @param  string            $type     ETag type: "strong" or "weak"
-     *
-     * @return ResponseInterface           A new PSR7 response object with `ETag` header
-     * @throws InvalidArgumentException if the etag type is invalid
-     */
-    public function withEtag(ResponseInterface $response, $value, $type = 'strong')
-    {
-        if (!in_array($type, ['strong', 'weak'])) {
-            throw new InvalidArgumentException('Invalid etag type. Must be "strong" or "weak".');
-        }
-        $value = '"' . $value . '"';
-        if ($type === 'weak') {
-            $value = 'W/' . $value;
-        }
-
-        return $response->withHeader('ETag', $value);
-    }
-
-    /**
-     * Add `Last-Modified` header to PSR7 response object
-     *
-     * @param  ResponseInterface $response A PSR7 response object
-     * @param  int|string        $time     A UNIX timestamp or a valid `strtotime()` string
-     *
-     * @return ResponseInterface           A new PSR7 response object with `Last-Modified` header
-     * @throws InvalidArgumentException if the last modified date cannot be parsed
-     */
-    public function withLastModified(ResponseInterface $response, $time)
-    {
-        if (!is_integer($time)) {
-            $time = strtotime($time);
-            if ($time === false) {
-                throw new InvalidArgumentException('Last Modified value could not be parsed with `strtotime()`.');
-            }
-        }
-
-        return $response->withHeader('Last-Modified', gmdate('D, d M Y H:i:s T', $time));
+        $container['cache'] = function () {
+            return new CacheHelper();
+        };
     }
 }

--- a/tests/CacheHelperTest.php
+++ b/tests/CacheHelperTest.php
@@ -1,0 +1,153 @@
+<?php
+namespace Slim\Middleware\HttpCache\Tests;
+
+use Slim\Http\Response;
+use Slim\Middleware\HttpCache\CacheHelper;
+
+class CacheHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CacheHelper
+     */
+    protected $cache;
+
+    protected function setUp()
+    {
+        $this->cache = new CacheHelper();
+    }
+
+    public function testAllowCache()
+    {
+        $res = $this->cache->allowCache(new Response(), 'private', 43200);
+
+        $cacheControl = $res->getHeaderLine('Cache-Control');
+
+        $this->assertEquals('private, max-age=43200', $cacheControl);
+    }
+
+    public function testDenyCache()
+    {
+        $res = $this->cache->denyCache(new Response());
+
+        $cacheControl = $res->getHeaderLine('Cache-Control');
+
+        $this->assertEquals('no-store,no-cache', $cacheControl);
+    }
+
+    public function testWithExpires()
+    {
+        $now = time();
+        $res = $this->cache->withExpires(new Response(), $now);
+
+        $expires = $res->getHeaderLine('Expires');
+
+        $this->assertEquals(gmdate('D, d M Y H:i:s T', $now), $expires);
+    }
+
+    public function testWithETag()
+    {
+        $etag = 'abc';
+        $res = $this->cache->withEtag(new Response(), $etag);
+
+        $etagHeader = $res->getHeaderLine('ETag');
+
+        $this->assertEquals('"' . $etag . '"', $etagHeader);
+    }
+
+    public function testWithETagWeak()
+    {
+        $etag = 'abc';
+        $res = $this->cache->withEtag(new Response(), $etag, 'weak');
+
+        $etagHeader = $res->getHeaderLine('ETag');
+
+        $this->assertEquals('W/"' . $etag . '"', $etagHeader);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithETagInvalidType()
+    {
+        $etag = 'abc';
+        $this->cache->withEtag(new Response(), $etag, 'bork');
+    }
+
+    public function testWithLastModified()
+    {
+        $now = time();
+        $res = $this->cache->withLastModified(new Response(), $now);
+
+        $lastModified = $res->getHeaderLine('Last-Modified');
+
+        $this->assertEquals(gmdate('D, d M Y H:i:s T', $now), $lastModified);
+    }
+
+    /**
+     * @return array
+     */
+    public function modifiedTimes()
+    {
+        return [
+            'same-time' => [0, true],
+            'current-time-older' => [172800, true],
+            'current-time-newer' => [-86400, false],
+        ];
+    }
+
+    /**
+     * @covers Slim\Middleware\HttpCache\CacheHelper::isStillValid
+     * @dataProvider modifiedTimes
+     * @param int $offsetLastRequest
+     * @param bool $valid
+     */
+    public function testisValidWithLastModified($offsetLastRequest, $valid)
+    {
+        $now = time();
+        $lastModified = gmdate('D, d M Y H:i:s T', $now);
+        $ifModifiedSince = gmdate('D, d M Y H:i:s T', $now + $offsetLastRequest);
+
+        $req = $this->getMockBuilder('Slim\Http\Request')->disableOriginalConstructor()->getMock();
+        $req->expects($this->once())
+            ->method('getHeaderLine')
+            ->with('If-Modified-Since')
+            ->will($this->returnValue($ifModifiedSince));
+
+        $res = new Response();
+        $res = $res->withHeader('Last-Modified', $lastModified);
+
+        $this->assertSame($valid, $this->cache->isStillValid($req, $res));
+    }
+
+    /**
+     * @return array
+     */
+    public function eTags()
+    {
+        return [
+            'hit' => ['abc', 'abc', true],
+            'miss' => ['abc', 'xyz', false],
+        ];
+    }
+
+    /**
+     * @covers Slim\Middleware\HttpCache\CacheHelper::isStillValid
+     * @dataProvider eTags
+     * @param string $eTag
+     * @param string $ifNoneMatch
+     * @param bool $valid
+     */
+    public function testIsValidWithETag($eTag, $ifNoneMatch, $valid)
+    {
+        $req = $this->getMockBuilder('Slim\Http\Request')->disableOriginalConstructor()->getMock();
+        $req->expects($this->once())
+            ->method('getHeaderLine')
+            ->with('If-None-Match')
+            ->will($this->returnValue($ifNoneMatch));
+
+        $res = new Response();
+        $res = $res->withHeader('ETag', $eTag);
+
+        $this->assertSame($valid, $this->cache->isStillValid($req, $res));
+    }
+}

--- a/tests/CacheProviderTest.php
+++ b/tests/CacheProviderTest.php
@@ -1,82 +1,20 @@
 <?php
-namespace Slim\HttpCache\Tests;
+namespace Slim\Middleware\HttpCache\Tests;
 
-use Slim\HttpCache\CacheProvider;
-use Slim\Http\Response;
+use Pimple\Container;
+use Slim\Middleware\HttpCache\CacheProvider;
 
 class CacheProviderTest extends \PHPUnit_Framework_TestCase
 {
-    public function testAllowCache()
-    {
-        $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->allowCache(new Response(), 'private', 43200);
-
-        $cacheControl = $res->getHeaderLine('Cache-Control');
-
-        $this->assertEquals('private, max-age=43200', $cacheControl);
-    }
-
-    public function testDenyCache()
-    {
-        $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->denyCache(new Response());
-
-        $cacheControl = $res->getHeaderLine('Cache-Control');
-
-        $this->assertEquals('no-store,no-cache', $cacheControl);
-    }
-
-    public function testWithExpires()
-    {
-        $now = time();
-        $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withExpires(new Response(), $now);
-
-        $expires = $res->getHeaderLine('Expires');
-
-        $this->assertEquals(gmdate('D, d M Y H:i:s T', $now), $expires);
-    }
-
-    public function testWithETag()
-    {
-        $etag = 'abc';
-        $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withEtag(new Response(), $etag);
-
-        $etagHeader = $res->getHeaderLine('ETag');
-
-        $this->assertEquals('"' . $etag . '"', $etagHeader);
-    }
-
-    public function testWithETagWeak()
-    {
-        $etag = 'abc';
-        $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withEtag(new Response(), $etag, 'weak');
-
-        $etagHeader = $res->getHeaderLine('ETag');
-
-        $this->assertEquals('W/"' . $etag . '"', $etagHeader);
-    }
-
     /**
-     * @expectedException \InvalidArgumentException
+     * @covers Slim\Middleware\HttpCache\CacheProvider::register
      */
-    public function testWithETagInvalidType()
+    public function testRegister()
     {
-        $etag = 'abc';
-        $cacheProvider = new CacheProvider();
-        $cacheProvider->withEtag(new Response(), $etag, 'bork');
-    }
+        $container = new Container();
+        $container->register(new CacheProvider());
 
-    public function testWithLastModified()
-    {
-        $now = time();
-        $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withLastModified(new Response(), $now);
-
-        $lastModified = $res->getHeaderLine('Last-Modified');
-
-        $this->assertEquals(gmdate('D, d M Y H:i:s T', $now), $lastModified);
+        $this->assertTrue($container->offsetExists('cache'));
+        $this->assertInstanceOf('Slim\Middleware\HttpCache\CacheHelper', $container->offsetGet('cache'));
     }
 }


### PR DESCRIPTION
This pull requests separates the cache relevant methods into one class called `CacheHelper`. All classes are now under the `Slim\Middleware` namespace.

Overview of the classes:
* `CacheHelper`: Helper class with methods to set cache relevant headers and to determine if the client side cache is still valid. The methods can be used in the application (fixes #10).
* `CacheProvider`: Only adds a `CacheHelper` object to the container (fixes #7).
* `Cache`: Middleware to automatically set default cache headers and status code `304` if necessary. Uses the `CacheHelper` class to remove code duplication.

The `CacheHelper` and `Cache` objects are independent, if you only want helper methods or only want to add default cache headers, you can do so.