### PR TITLE
Use no-cache header when max-age is zero

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -56,12 +56,20 @@ class Cache
 
         // Cache-Control header
         if (!$response->hasHeader('Cache-Control')) {
-            $response = $response->withHeader('Cache-Control', sprintf(
-                '%s, max-age=%s%s',
-                $this->type,
-                $this->maxAge,
-                $this->mustRevalidate ? ', must-revalidate' : ''
-            ));
+            if ($this->maxAge === 0) {
+                $response = $response->withHeader('Cache-Control', sprintf(
+                    '%s, no-cache%s',
+                    $this->type,
+                    $this->mustRevalidate ? ', must-revalidate' : ''
+                ));
+            } else {
+                $response = $response->withHeader('Cache-Control', sprintf(
+                    '%s, max-age=%s%s',
+                    $this->type,
+                    $this->maxAge,
+                    $this->mustRevalidate ? ', must-revalidate' : ''
+                ));
+            }
         }
 
         // Last-Modified header and conditional GET check

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -52,6 +52,21 @@ class CacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('private, max-age=86400, must-revalidate', $cacheControl);
     }
 
+    public function testCacheControlHeaderWithZeroMaxAge()
+    {
+        $cache = new Cache('private', 0, false);
+        $req = $this->requestFactory();
+        $res = new Response();
+        $next = function (Request $req, Response $res) {
+            return $res;
+        };
+        $res = $cache($req, $res, $next);
+
+        $cacheControl = $res->getHeaderLine('Cache-Control');
+
+        $this->assertEquals('private, no-cache', $cacheControl);
+    }
+
     public function testCacheControlHeaderDoesNotOverrideExistingHeader()
     {
         $cache = new Cache('public', 86400);


### PR DESCRIPTION
You could previously accomplish this by doing something like this 

`$app->add(new \Slim\HttpCache\Cache('private, no-cache', 0, true));`

But this results in a header like this: "private, no-cache, max-age=0, must-revalidate".

A neater header that is more standard is "private, no-cache" which will have the effect of stipulating that the cache MUST NOT use the response to satisfy a subsequent request without successful revalidation with the origin server. 