### PR TITLE
Fixed relative max-age format

### DIFF
--- a/src/CacheProvider.php
+++ b/src/CacheProvider.php
@@ -25,7 +25,7 @@ class CacheProvider
         $headerValue = $type;
         if ($maxAge || is_integer($maxAge)) {
             if (!is_integer($maxAge)) {
-                $maxAge = strtotime($maxAge);
+                $maxAge = strtotime($maxAge) - time();
             }
             $headerValue = $headerValue . ', max-age=' . $maxAge;
         }

--- a/tests/CacheProviderTest.php
+++ b/tests/CacheProviderTest.php
@@ -16,6 +16,16 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('private, max-age=43200', $cacheControl);
     }
 
+    public function testAllowCacheWithRelativeMaxAge()
+    {
+        $cacheProvider = new CacheProvider();
+        $res = $cacheProvider->allowCache(new Response(), 'private', '+12 hours');
+
+        $cacheControl = $res->getHeaderLine('Cache-Control');
+
+        $this->assertEquals('private, max-age=43200', $cacheControl);
+    }
+
     public function testAllowCacheWithMustRevalidate()
     {
         $cacheProvider = new CacheProvider();


### PR DESCRIPTION
``` php
$cacheProvider->allowCache($response, 'private', '+12 hours');
// should not be: private, max-age=1539965032
// but should be: private, max-age=43200
```
