### PR TITLE
Update the cache middleware to support slim 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script: composer install
 
-script: phpunit --coverage-text
+script: vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This repository contains a Slim Framework HTTP cache middleware and service provider.
 
+## Requirements
+
+- PHP 7.1 or newer
+
 ## Install
 
 Via Composer
@@ -12,12 +16,15 @@ Via Composer
 $ composer require slim/http-cache
 ```
 
-Requires Slim 3.0.0 or newer.
-
 ## Usage
 
 ```php
-$app = new \Slim\App();
+// Create Container using PHP-DI
+$container = new Container();
+
+// Set container to create App with on AppFactory
+AppFactory::setContainer($container);
+$app = AppFactory::create();
 
 // Register middleware
 $app->add(new \Slim\HttpCache\Cache('public', 86400));
@@ -26,9 +33,9 @@ $app->add(new \Slim\HttpCache\Cache('public', 86400));
 $container = $app->getContainer();
 
 // Register service provider
-$container['cache'] = function () {
+$container->set('cache', function () {
     return new \Slim\HttpCache\CacheProvider();
-};
+});
 
 // Example route with ETag header
 $app->get('/foo', function ($req, $res, $args) {
@@ -43,7 +50,7 @@ $app->run();
 ## Testing
 
 ``` bash
-$ phpunit
+$ vendor/bin/phpunit
 ```
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,13 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.1",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "slim/slim": "^3.0",
-        "phpunit/phpunit": "^4.0"
+        "slim/slim": "^4.0",
+        "phpunit/phpunit": "^4.0",
+        "slim/psr7": "^0.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="./vendor/autoload.php"
 >
     <testsuites>
         <testsuite name="Slim Test Suite">

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,10 +1,12 @@
 <?php
 namespace Slim\HttpCache;
 
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
-class Cache
+class Cache implements MiddlewareInterface
 {
     /**
      * Cache-Control type (public or private)
@@ -42,17 +44,11 @@ class Cache
     }
 
     /**
-     * Invoke cache middleware
-     *
-     * @param  RequestInterface  $request  A PSR7 request object
-     * @param  ResponseInterface $response A PSR7 response object
-     * @param  callable          $next     The next middleware callable
-     *
-     * @return ResponseInterface           A PSR7 response object
+     * {@inheritDoc}
      */
-    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $response = $next($request, $response);
+        $response = $handler->handle($request);
 
         // Cache-Control header
         if (!$response->hasHeader('Cache-Control')) {

--- a/tests/CacheProviderTest.php
+++ b/tests/CacheProviderTest.php
@@ -1,15 +1,22 @@
 <?php
 namespace Slim\HttpCache\Tests;
 
+use Psr\Http\Message\ResponseInterface;
 use Slim\HttpCache\CacheProvider;
-use Slim\Http\Response;
+use Slim\Psr7\Factory\ResponseFactory;
 
 class CacheProviderTest extends \PHPUnit_Framework_TestCase
 {
+    private function createResponse(): ResponseInterface
+    {
+        $responseFactory = new ResponseFactory();
+        return $responseFactory->createResponse();
+    }
+
     public function testAllowCache()
     {
         $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->allowCache(new Response(), 'private', 43200);
+        $res = $cacheProvider->allowCache($this->createResponse(), 'private', 43200);
 
         $cacheControl = $res->getHeaderLine('Cache-Control');
 
@@ -19,7 +26,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     public function testAllowCacheWithMustRevalidate()
     {
         $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->allowCache(new Response(), 'private', 43200, true);
+        $res = $cacheProvider->allowCache($this->createResponse(), 'private', 43200, true);
 
         $cacheControl = $res->getHeaderLine('Cache-Control');
 
@@ -29,7 +36,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     public function testDenyCache()
     {
         $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->denyCache(new Response());
+        $res = $cacheProvider->denyCache($this->createResponse());
 
         $cacheControl = $res->getHeaderLine('Cache-Control');
 
@@ -40,7 +47,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     {
         $now = time();
         $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withExpires(new Response(), $now);
+        $res = $cacheProvider->withExpires($this->createResponse(), $now);
 
         $expires = $res->getHeaderLine('Expires');
 
@@ -51,7 +58,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     {
         $etag = 'abc';
         $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withEtag(new Response(), $etag);
+        $res = $cacheProvider->withEtag($this->createResponse(), $etag);
 
         $etagHeader = $res->getHeaderLine('ETag');
 
@@ -62,7 +69,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     {
         $etag = 'abc';
         $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withEtag(new Response(), $etag, 'weak');
+        $res = $cacheProvider->withEtag($this->createResponse(), $etag, 'weak');
 
         $etagHeader = $res->getHeaderLine('ETag');
 
@@ -76,14 +83,14 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     {
         $etag = 'abc';
         $cacheProvider = new CacheProvider();
-        $cacheProvider->withEtag(new Response(), $etag, 'bork');
+        $cacheProvider->withEtag($this->createResponse(), $etag, 'bork');
     }
 
     public function testWithLastModified()
     {
         $now = time();
         $cacheProvider = new CacheProvider();
-        $res = $cacheProvider->withLastModified(new Response(), $now);
+        $res = $cacheProvider->withLastModified($this->createResponse(), $now);
 
         $lastModified = $res->getHeaderLine('Last-Modified');
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,0 @@
-<?php
-require dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
Heya 👋 

So I'm not sure if this PR is going in the right direction but I noticed that we couldn't use this as middleware in the latest slim framework (v4). I've updated the implementation to match the `MiddlewareInterface` and updated the tests so they create the required classes in the right way.

One thing I'm not sure on is whether the use of `slim/psr-7` is desired, I think i only really use it to easily create request/response objects. In the main slim repo I've noticed we do it slightly differently but I don't know if how I've written the tests is an issue here. What do you think?

Lastly while I've got the suite green I just want to sanity check this middleware on v4 of the framework but wanted to get some early feedback on whether this is something that you guys wanted.

Thanks

### TODO
- [ ] Test this middleware against v4 of `slim/slim`