### PR TITLE
Add support for psr/http-message 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^7.2 || ^8.0",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.1 || ^2.0",
     "psr/http-server-middleware": "^1.0"
   },
   "require-dev": {

--- a/src/CacheProvider.php
+++ b/src/CacheProvider.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\ResponseInterface;
 use function gmdate;
 use function in_array;
 use function is_integer;
-use function is_null;
 use function strtotime;
 use function time;
 
@@ -43,7 +42,7 @@ class CacheProvider
         }
         $headerValue = $type;
         if ($maxAge || is_integer($maxAge)) {
-            if (!is_integer($maxAge) && !is_null($maxAge)) {
+            if (!is_integer($maxAge) && $maxAge !== null) {
                 $maxAge = strtotime($maxAge) - time();
             }
             $headerValue = $headerValue.', max-age='.$maxAge;


### PR DESCRIPTION
This PR bumps the `psr/http-message` constraint from `^1.0` to `^1.1 || ^2.0`.

It follows the same constraint as [slimphp/Slim](https://github.com/slimphp/Slim/blob/4.x/composer.json#L51).

Similar change to:

* https://github.com/slimphp/Slim-Psr7/pull/289
* https://github.com/slimphp/Twig-View/pull/312
* https://github.com/slimphp/Slim-Http/pull/237
* https://github.com/slimphp/Slim-Csrf/pull/184